### PR TITLE
initial group-by implementation

### DIFF
--- a/ndc-duckduckapi/package-lock.json
+++ b/ndc-duckduckapi/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hasura/ndc-lambda-sdk": "^1.9.0",
+        "@hasura/ndc-sdk-typescript": "^8.0.0-rc.0",
         "@tsconfig/node20": "^20.1.4",
         "duckdb": "^1.1.1",
         "duckdb-async": "^1.1.1",
@@ -642,7 +643,7 @@
         "ndc-lambda-sdk": "bin/index.js"
       }
     },
-    "node_modules/@hasura/ndc-sdk-typescript": {
+    "node_modules/@hasura/ndc-lambda-sdk/node_modules/@hasura/ndc-sdk-typescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-7.0.0.tgz",
       "integrity": "sha512-y2ftrTQwtNZz9DmQXla/R/PDTgsSBxdA97uyq5zsAaBT9OjL9rAkRkXjkJdBC4GOXU+AsqSnsrDBn5pFvzzbxw==",
@@ -664,6 +665,31 @@
         "fastify": "^4.23.2",
         "pino-pretty": "^10.2.3",
         "prom-client": "^15.1.2"
+      }
+    },
+    "node_modules/@hasura/ndc-sdk-typescript": {
+      "version": "8.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-8.0.0-rc.0.tgz",
+      "integrity": "sha512-WsDa3mKD0fhhX1itvtfUrw+WuEQaL3JNP5o2dmh8seId1kD0yTju0SrtZDKPxQl1dZoYkrYhOyLM/VfMCPQtYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-schema-tools/meta-schema": "^1.7.0",
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.53.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.53.0",
+        "@opentelemetry/instrumentation-fastify": "^0.36.0",
+        "@opentelemetry/instrumentation-fetch": "^0.53.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
+        "@opentelemetry/instrumentation-pino": "^0.38.0",
+        "@opentelemetry/resources": "^1.24.0",
+        "@opentelemetry/sdk-metrics": "^1.24.0",
+        "@opentelemetry/sdk-node": "^0.51.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0",
+        "commander": "^11.0.0",
+        "fastify": "^4.23.2",
+        "pino-pretty": "^10.2.3",
+        "prom-client": "^15.1.2",
+        "semver": "^7.6.3"
       }
     },
     "node_modules/@hasura/ts-node-dev": {

--- a/ndc-duckduckapi/package.json
+++ b/ndc-duckduckapi/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@hasura/ndc-lambda-sdk": "^1.9.0",
+    "@hasura/ndc-sdk-typescript": "^8.0.0-rc.0",
     "@tsconfig/node20": "^20.1.4",
     "duckdb": "^1.1.1",
     "duckdb-async": "^1.1.1",

--- a/ndc-duckduckapi/src/constants.ts
+++ b/ndc-duckduckapi/src/constants.ts
@@ -1,20 +1,25 @@
 import { Capabilities, ScalarType } from "@hasura/ndc-sdk-typescript";
-import { JSONSchemaObject } from "@json-schema-tools/meta-schema";
+// import { JSONSchemaObject } from "@json-schema-tools/meta-schema";
 
 export const CAPABILITIES_RESPONSE: Capabilities = {
   query: {
     variables: {},
-    nested_fields: {},
-    aggregates: {}
+    aggregates: {
+      group_by: {
+        filter: {},
+        order: {},
+        paginate: {}
+      }
+    }
   },
   mutation: {
     transactional: null,
-    explain: null,
+    explain: null
   },
   relationships: {
     order_by_aggregate: {},
-    relation_comparisons: {},
-  },
+    relation_comparisons: {}
+  }
 };
 export const MAX_32_INT: number = 2147483647;
 export const SCALAR_TYPES: { [key: string]: ScalarType } = {
@@ -23,12 +28,68 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
       type: "biginteger"
     },
     aggregate_functions: {
-      // sum: {
-      //   result_type: {
-      //     type: "named",
-      //     name: "Int"
-      //   }
-      // }
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigInt"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max",
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
     },
     comparison_operators: {
       _eq: {
@@ -75,7 +136,70 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
     representation: {
       type: "biginteger"
     },
-    aggregate_functions: {},
+    aggregate_functions: {
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "UBigInt"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max"
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
+    },
     comparison_operators: {
       _eq: { type: "equal" },
       _gt: { type: "custom", argument_type: { type: "named", name: "UBigInt" }},
@@ -89,7 +213,70 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
     representation: {
       type: "biginteger"
     },
-    aggregate_functions: {},
+    aggregate_functions: {
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "HugeInt"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max"
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
+    },
     comparison_operators: {
       _eq: { type: "equal" },
       _gt: { type: "custom", argument_type: { type: "named", name: "HugeInt" }},
@@ -103,7 +290,70 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
     representation: {
       type: "biginteger"
     },
-    aggregate_functions: {},
+    aggregate_functions: {
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "UHugeInt"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max"
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
+    },
     comparison_operators: {
       _eq: { type: "equal" },
       _gt: { type: "custom", argument_type: { type: "named", name: "UHugeInt" }},
@@ -113,111 +363,346 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
       _neq: { type: "custom", argument_type: { type: "named", name: "UHugeInt" }},
     },
   },
-  Int: {
-    aggregate_functions: {
-      // sum: {
-      //   result_type: {
-      //     type: "named",
-      //     name: "Int"
-      //   }
-      // }
+  Timestamp: {
+    representation: {
+      type: "timestamp"
     },
-    comparison_operators: {
-      _eq: {
-        type: "equal",
-      },
-      _gt: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Int",
-        },
-      },
-      _lt: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Int",
-        },
-      },
-      _gte: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Int",
-        },
-      },
-      _lte: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Int",
-        },
-      },
-      _neq: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Int",
-        },
-      },
-    },
-  },
-  Float: {
-    aggregate_functions: {
-      // sum: {
-      //   result_type: {
-      //     type: "named",
-      //     name: "Float"
-      //   }
-      // }
-    },
-    comparison_operators: {
-      _eq: {
-        type: "equal",
-      },
-      _gt: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Float",
-        },
-      },
-      _lt: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Float",
-        },
-      },
-      _gte: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Float",
-        },
-      },
-      _lte: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Float",
-        },
-      },
-      _neq: {
-        type: "custom",
-        argument_type: {
-          type: "named",
-          name: "Float",
-        },
-      },
-    },
-  },
-  String: {
     aggregate_functions: {},
     comparison_operators: {
       _eq: {
         type: "equal",
+      },
+      _gt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Timestamp",
+        },
+      },
+      _lt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Timestamp",
+        },
+      },
+      _gte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Timestamp",
+        },
+      },
+      _lte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Timestamp",
+        },
+      },
+      _neq: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Timestamp",
+        },
+      },
+    },
+  },
+  TimestampTz: {
+    representation: {
+      type: "timestamptz"
+    },
+    aggregate_functions: {},
+    comparison_operators: {
+      _eq: {
+        type: "equal",
+      },
+      _gt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "TimestampTz",
+        },
+      },
+      _lt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "TimestampTz",
+        },
+      },
+      _gte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "TimestampTz",
+        },
+      },
+      _lte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "TimestampTz",
+        },
+      },
+      _neq: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "TimestampTz",
+        },
+      },
+    },
+  },
+  Int: {
+    representation: {
+      type: "int64"
+    },
+    aggregate_functions: {
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigInt"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max"
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
+    },
+    comparison_operators: {
+      _eq: {
+        type: "equal"
+      },
+      _gt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Int",
+        },
+      },
+      _lt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Int",
+        },
+      },
+      _gte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Int",
+        },
+      },
+      _lte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Int",
+        },
+      },
+      _neq: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Int",
+        },
+      },
+    }
+  },
+  Float: {
+    representation: {
+      type: "float64"
+    },
+    aggregate_functions: {
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max"
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
+    },
+    comparison_operators: {
+      _eq: {
+        type: "equal"
+      },
+      _gt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Float",
+        },
+      },
+      _lt: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Float",
+        },
+      },
+      _gte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Float",
+        },
+      },
+      _lte: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Float",
+        },
+      },
+      _neq: {
+        type: "custom",
+        argument_type: {
+          type: "named",
+          name: "Float",
+        },
+      },
+    }
+  },
+  String: {
+    representation: {
+      type: "string"
+    },
+    aggregate_functions: {
+      _group_concat: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "String"
+        }
+      },
+      _group_concat_distinct: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "String"
+        }
+      },
+      _group_concat_include_nulls: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "String"
+        }
+      }
+    },
+    comparison_operators: {
+      _eq: {
+        type: "equal"
       },
       _like: {
         type: "custom",
@@ -268,10 +753,87 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
           name: "String",
         },
       },
+    }
+  },
+  Boolean: {
+    representation: {
+      type: "boolean"
+    },
+    aggregate_functions: {},
+    comparison_operators: {
+      _eq: {
+        type: "equal"
+      },
     },
   },
-  Timestamp: {
-    aggregate_functions: {},
+  BigDecimal: {
+    representation: {
+      type: "bigdecimal"
+    },
+    aggregate_functions: {
+      _sum: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _avg: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _max: {
+        type: "max"
+      },
+      _min: {
+        type: "min"
+      },
+      _stddev: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _stddev_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _variance: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_samp: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      },
+      _var_pop: {
+        type: "custom",
+        result_type: {
+          type: "named",
+          name: "BigDecimal"
+        }
+      }
+    },
     comparison_operators: {
       _eq: {
         type: "equal",
@@ -280,44 +842,36 @@ export const SCALAR_TYPES: { [key: string]: ScalarType } = {
         type: "custom",
         argument_type: {
           type: "named",
-          name: "Timestamp",
+          name: "BigDecimal",
         },
       },
       _lt: {
         type: "custom",
         argument_type: {
           type: "named",
-          name: "Timestamp",
+          name: "BigDecimal",
         },
       },
       _gte: {
         type: "custom",
         argument_type: {
           type: "named",
-          name: "Timestamp",
+          name: "BigDecimal",
         },
       },
       _lte: {
         type: "custom",
         argument_type: {
           type: "named",
-          name: "Timestamp",
+          name: "BigDecimal",
         },
       },
       _neq: {
         type: "custom",
         argument_type: {
           type: "named",
-          name: "Timestamp",
+          name: "BigDecimal",
         },
-      },
-    },
-  },
-  Boolean: {
-    aggregate_functions: {},
-    comparison_operators: {
-      _eq: {
-        type: "equal",
       },
     },
   },

--- a/ndc-duckduckapi/src/generate-config.ts
+++ b/ndc-duckduckapi/src/generate-config.ts
@@ -66,10 +66,9 @@ const determineType = (t: string): string => {
     case "JSON":
       return "JSON";
     default:
-      if (t.startsWith("DECIMAL")) {
-        return "Float";
+      if (t.startsWith("DECIMAL") || t.startsWith("NUMERIC")){
+        return "BigDecimal";
       }
-      console.log(t);
       throw new NotSupported("Unsupported type", {});
   }
 };
@@ -126,6 +125,7 @@ export async function generateConfig(
     if (!objectTypes[tableName]) {
       objectTypes[tableName] = {
         fields: {},
+        foreign_keys: {},
         description:
           tableCommentMap.get(tableName) || "No description available",
       };

--- a/ndc-duckduckapi/src/handlers/schema.ts
+++ b/ndc-duckduckapi/src/handlers/schema.ts
@@ -20,7 +20,6 @@ export function do_get_schema(duckdbconfig: DuckDBConfigurationSchema, functions
         arguments: {},
         type: cn,
         uniqueness_constraints: {},
-        foreign_keys: {},
         description: object_types[cn].description
       });
     }


### PR DESCRIPTION
This PR adds initial support for GroupBy

There are additional features that need added, including push-downs for Group by. This initial version will allow PromptQL to access GroupBy through the SQL layer.

This SHOULD NOT BE MERGED until v0.2.0 lands.